### PR TITLE
Initialize Swift SDK package structure

### DIFF
--- a/sdks/swift/.gitignore
+++ b/sdks/swift/.gitignore
@@ -1,0 +1,3 @@
+.build/
+.swiftpm/
+Package.resolved

--- a/sdks/swift/Package.swift
+++ b/sdks/swift/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "SpacetimeDB",
+    products: [
+        .library(
+            name: "SpacetimeDB",
+            targets: ["SpacetimeDB"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "SpacetimeDB"
+        )
+    ]
+)

--- a/sdks/swift/Sources/SpacetimeDB/SpacetimeDB.swift
+++ b/sdks/swift/Sources/SpacetimeDB/SpacetimeDB.swift
@@ -1,0 +1,3 @@
+public struct SpacetimeDB {
+    public init() {}
+}


### PR DESCRIPTION
## Summary
- add foundational Swift package manifest and sources directory under `sdks/swift`
- include minimal `SpacetimeDB` library target with placeholder struct
- ignore Swift build artifacts

## Testing
- `cd sdks/swift && swift build`
- `swift test` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689a9187f36c832c80e9f1ebeb2ac302